### PR TITLE
Make A11yTest / test task depend on a11yInstall task

### DIFF
--- a/src/main/scala/uk/gov/hmrc/AccessibilityLinterPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/AccessibilityLinterPlugin.scala
@@ -54,7 +54,10 @@ object AccessibilityLinterPlugin extends AutoPlugin with LibraryManagementSyntax
 
     lazy val a11yTestSettings: Seq[Setting[_]] =
       inConfig(A11yTest)(Defaults.testSettings) ++
-        Seq(A11yTest / unmanagedSourceDirectories := (A11yTest / baseDirectory)(base => Seq(base / "a11y")).value)
+        Seq(
+          A11yTest / unmanagedSourceDirectories := (A11yTest / baseDirectory) (base => Seq(base / "a11y")).value,
+          A11yTest / test := (A11yTest / test).dependsOn(a11yInstall).value
+        )
   }
 
   import autoImport._
@@ -70,7 +73,6 @@ object AccessibilityLinterPlugin extends AutoPlugin with LibraryManagementSyntax
     a11yRoot := a11yRootTask.value,
     a11yExtract := a11yExtractTask.value,
     a11yInstall := a11yInstallTask.value,
-    A11yTest / testOptions := Seq(Tests.Setup( () => a11yInstall.value )),
     libraryDependencies ++= Seq(
       "uk.gov.hmrc" %% "scalatest-accessibility-linter" % "0.15.0" % Test
     ),


### PR DESCRIPTION
what about this? seems to run from a check of `sbt scripted` but I also don't really fully comprehend the web of sbt stuff